### PR TITLE
Switch body/heading font to Charter and refine home layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,10 +6,31 @@
     <meta charset="utf-8">
     <title>{{ page.title }} - {{ site.title }}</title>
 
-    <!-- Google Fonts - Serif for body, Sans-serif for headings -->
+    <!-- Fonts: Charter (system on macOS/iOS) + Inter for UI. Charter webfont fallback for other platforms. -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+      /* Charter webfont fallback for Windows/Linux (macOS/iOS users get the local Charter) */
+      @font-face {
+        font-family: 'Charter';
+        src: local('Charter'), local('Charter Regular'),
+             url('https://fonts.cdnfonts.com/s/13909/Charter%20Regular.woff') format('woff');
+        font-weight: 400; font-style: normal; font-display: swap;
+      }
+      @font-face {
+        font-family: 'Charter';
+        src: local('Charter Italic'), local('Charter-Italic'),
+             url('https://fonts.cdnfonts.com/s/13909/Charter%20Italic.woff') format('woff');
+        font-weight: 400; font-style: italic; font-display: swap;
+      }
+      @font-face {
+        font-family: 'Charter';
+        src: local('Charter Bold'), local('Charter-Bold'),
+             url('https://fonts.cdnfonts.com/s/13909/Charter%20Bold.woff') format('woff');
+        font-weight: 700; font-style: normal; font-display: swap;
+      }
+    </style>
 
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -143,31 +143,30 @@ layout: default
 </div>
 
 <style>
-/* Layout */
+/* Layout — generous whitespace, academic measure */
 .wrapper {
     display: flex;
-    gap: 2.25rem;
-    max-width: 1200px;
+    gap: 3rem;
+    max-width: 1120px;
     margin: 0 auto;
-    padding: 20px;
-    min-height: calc(100vh - 160px);  /* Subtract header + footer height */
+    padding: 28px 24px;
+    min-height: calc(100vh - 160px);
 }
 
-/* Sidebar Styles */
-
-
+/* Sidebar — flat, quiet, Philcox/Asmar-inspired */
 .sidebar {
-    width: 300px;
+    width: 260px;
+    flex-shrink: 0;
     position: sticky;
-    top: 92px;  /* Adjust based on your header height */
-    max-height: calc(100vh - 116px);  /* Subtract header height + some padding */
+    top: 96px;
+    max-height: calc(100vh - 116px);
     overflow-y: auto;
-    padding: 1.6rem;
-    background: linear-gradient(180deg, var(--surface-1) 0%, var(--surface-2) 100%);
-    border: 1px solid var(--surface-border);
-    box-shadow: var(--surface-shadow);
-    border-radius: 22px;
-    margin-bottom: 2rem;  /* Add space at bottom */
+    padding: 0.5rem 0.25rem;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    margin-bottom: 2rem;
 }
 
 
@@ -175,36 +174,38 @@ layout: default
 
 
 .sidebar-content {
-  padding-top: 48px; /* Account for fixed header */
+  padding-top: 16px;
 }
 
 .author-avatar {
-  text-align: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.4rem;
 }
 
 .author-avatar-img {
-  width: 200px;
-  height: 200px;
-  border-radius: 50%;
+  width: 220px;
+  height: 220px;
+  border-radius: 4px;      /* square with soft corners — Philcox/Asmar feel */
   object-fit: cover;
-  border: 4px solid rgba(255, 255, 255, 0.75);
-  box-shadow: 0 10px 26px rgba(0,0,0,0.12);
+  border: none;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
 .author-info {
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }
 
 .author-name {
-  font-size: 1.5rem;
-  margin: 0 0 0.5rem 0;
+  font-family: var(--font-heading);
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin: 0 0 0.4rem 0;
+  letter-spacing: -0.01em;
 }
 
 .author-bio {
-  font-size: 0.96rem;
-  line-height: 1.65;
-  color: var(--muted-text);
+  font-size: 0.98rem;
+  line-height: 1.55;
+  color: var(--muted-text, #4a4a4a);
   margin-bottom: 1rem;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -18,9 +18,10 @@
     --gradient-cardinal: linear-gradient(135deg, #8C1515 0%, #B83A4B 50%, #8C1515 100%);
     --gradient-cardinal-subtle: linear-gradient(90deg, #8C1515 0%, #A02828 50%, #8C1515 100%);
 
-    /* Typography */
-    --font-body: 'Source Serif 4', Georgia, 'Times New Roman', serif;
-    --font-heading: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    /* Typography — Charter-first serif stack (macOS/iOS ship with Charter) */
+    --font-body: 'Charter', 'Bitstream Charter', 'Sitka Text', 'Iowan Old Style', Cambria, Georgia, 'Times New Roman', serif;
+    --font-heading: 'Charter', 'Bitstream Charter', 'Sitka Text', 'Iowan Old Style', Cambria, Georgia, serif;
+    --font-ui: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     --font-mono: 'SF Mono', 'Fira Code', Consolas, monospace;
 
     /* Spacing */
@@ -52,26 +53,40 @@ body {
     margin: 0;
     padding: 0;
     font-family: var(--font-body);
-    line-height: 1.7;
+    line-height: 1.65;
     color: var(--text-color);
     background-color: var(--background-color);
-    font-size: 1.05rem;
+    font-size: 1.0625rem;
+    font-feature-settings: "kern", "liga", "onum";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
 }
 
-/* Typography - Sans-serif for headings */
+/* Typography - Charter for headings with tighter tracking */
 h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-heading);
     font-weight: 600;
-    line-height: 1.3;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+    font-feature-settings: "kern", "liga", "lnum";
 }
 
-/* Navigation uses sans-serif */
+h1 { font-size: 2.1rem; }
+h2 { font-size: 1.55rem; }
+h3 { font-size: 1.25rem; }
+
+/* Navigation/UI uses sans-serif for contrast against serif body */
 .site-header,
 .site-nav,
 .nav-links,
 .page-link,
-.site-title {
-    font-family: var(--font-heading);
+.site-title,
+.menu-toggle,
+.theme-toggle,
+.back-to-top,
+.section-indicator {
+    font-family: var(--font-ui);
 }
 
 /* Code uses monospace */


### PR DESCRIPTION
- Replace Source Serif 4 with Charter-first system stack (local on macOS/iOS, cdnfonts webfont fallback elsewhere); retain Inter for nav/UI chrome only
- Tune base typography: 1.0625rem / 1.65 leading, kern+liga+onum features, antialiasing, tighter heading tracking
- Flatten home sidebar (drop gradient card + rounded border) and reshape avatar to soft-cornered square for a quieter, more editorial feel